### PR TITLE
Fix ibon concert parsing and enhance LIFF UI

### DIFF
--- a/liff/index.html
+++ b/liff/index.html
@@ -1,484 +1,178 @@
-<!-- liff/index.html -->
 <!doctype html>
 <html lang="zh-Hant">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>票數偵測 LIFF</title>
+  <title>ibon 演唱會活動清單</title>
   <script src="https://static.line-scdn.net/liff/edge/versions/2.23.1/sdk.js"></script>
   <style>
-    body { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Noto Sans TC",sans-serif; margin:16px; }
-    .row { display:flex; gap:12px; align-items:center; margin-top:8px; flex-wrap:wrap; }
-    .card { border:1px solid #ddd; border-radius:12px; padding:12px; margin:10px 0; }
-    .title { font-weight:700; }
-    .hint { color:#666; }
-    button { padding:8px 12px; border-radius:10px; border:1px solid #ccc; cursor:pointer; background:#fff; }
-    button.secondary { background:#f5f5f5; }
-    button.danger { background:#ffeaea; border-color:#ffbcbc; }
-    input { padding:6px 8px; border-radius:8px; border:1px solid #ccc; width:90px; }
-    #out { margin:8px 0; color:#999; }
-    .poster { width:100%; max-width:360px; border-radius:10px; margin:12px 0 6px; object-fit:cover; }
-    .buttons { gap:10px; }
-    .status { margin-top:6px; font-size:0.92em; }
+    :root {
+      color-scheme: light;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans TC", sans-serif;
+      margin: 16px;
+      background: #f7f8fa;
+      color: #222;
+    }
+    header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: #1a237e;
+    }
+    .controls {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    .controls label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+    }
+    input[type="number"] {
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid #c5c9d3;
+      width: 100px;
+      font-size: 1rem;
+    }
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 8px 16px;
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+      background: #ffffff;
+      border: 1px solid #d0d4e4;
+    }
+    button.primary {
+      background: #3949ab;
+      border-color: #3949ab;
+      color: #fff;
+    }
+    button.secondary {
+      background: #f4f5fb;
+    }
+    button.danger {
+      background: #ffe5e5;
+      border-color: #f5b7b1;
+      color: #c0392b;
+    }
+    button:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+    button:not(:disabled):active {
+      transform: scale(0.98);
+    }
+    #out {
+      margin-bottom: 12px;
+      color: #556;
+      min-height: 1.2rem;
+    }
+    .cards {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      border: 1px solid #e0e4ef;
+      box-shadow: 0 6px 16px rgba(31, 45, 90, 0.08);
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .card .title {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: #1f2d5a;
+    }
+    .card img {
+      width: 100%;
+      max-height: 220px;
+      object-fit: cover;
+      border-radius: 14px;
+      background: #f0f1f6;
+    }
+    .meta span {
+      display: block;
+      color: #444;
+      line-height: 1.5;
+    }
+    .links {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    .links a {
+      color: #1a73e8;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .links a:hover {
+      text-decoration: underline;
+    }
+    .status-text {
+      font-size: 0.95rem;
+      color: #2f4858;
+    }
+    .watch-state {
+      font-size: 0.9rem;
+      color: #59617a;
+    }
+    .buttons {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-top: 4px;
+    }
+    .feedback {
+      font-size: 0.9rem;
+      color: #1e5ba5;
+      min-height: 1rem;
+    }
+    .empty-message {
+      text-align: center;
+      padding: 32px 12px;
+      color: #6f7a90;
+      border-radius: 12px;
+      background: rgba(57, 73, 171, 0.08);
+    }
   </style>
 </head>
 <body>
-  <div class="row">
-    監看秒數：<input id="sec" type="number" min="15" step="1" value="30" />
-    <button id="reload">重新整理清單</button>
-  </div>
+  <header>
+    <h1>ibon 演唱會活動清單</h1>
+    <div class="controls">
+      <label for="sec">監看秒數：<input id="sec" type="number" min="15" step="1" value="30" /></label>
+      <button id="reload" class="secondary" type="button">重新整理清單</button>
+    </div>
+  </header>
   <div id="out" class="hint">初始化中…</div>
-  <div id="list"></div>
+  <div id="list" class="cards"></div>
 
-<script>
-/** ====== 你的設定（使用完整網域） ====== */
-var LIFF_ID = "2008066018-EMmpzmKo";  // 你的 LIFF ID
-var API     = "https://ticketsearch-933798663509.asia-east1.run.app/liff/activities"; // ← 改成你的完整網址
-var MIN_SEC = 15;
-var ACT_LIMIT = 30;
-/** ===================================== */
-
-function ensureSec(v){
-  var n = parseInt(v, 10);
-  if (isNaN(n) || n < MIN_SEC) n = MIN_SEC;
-  return n;
-}
-
-function buildActivitiesUrl(){
-  var u;
-  try {
-    u = new URL(API);
-  } catch (e) {
-    u = new URL(API, window.location.href);
-  }
-  u.searchParams.set("onlyConcert", "1");
-  if (ACT_LIMIT && !isNaN(ACT_LIMIT)) {
-    u.searchParams.set("limit", String(ACT_LIMIT));
-  }
-  return u.toString();
-}
-
-function computeStatusApi(){
-  var u;
-  try {
-    u = new URL(API);
-  } catch (e) {
-    u = new URL(API, window.location.href);
-  }
-  var parts = u.pathname.split("/").filter(function(p){ return p; });
-  if (parts.length === 0){
-    parts = ["liff", "watch_status"];
-  } else {
-    parts[parts.length - 1] = "watch_status";
-  }
-  u.pathname = "/" + parts.join("/");
-  u.search = "";
-  u.hash = "";
-  return u.toString();
-}
-
-var STATUS_API = computeStatusApi();
-
-function openExternal(url){
-  if (!url) return false;
-  if (!liff.isInClient()) {
-    return false;
-  }
-  try {
-    liff.openWindow({ url: url, external: true });
-    return true;
-  } catch (err) {
-    console.warn("openWindow failed", err);
-    return false;
-  }
-}
-
-function attachExternalHandler(node, url){
-  if (!node || !url) return;
-  node.addEventListener("click", function(ev){
-    if (!liff.isInClient()) return;
-    ev.preventDefault();
-    if (!openExternal(url)) {
-      window.open(url, "_blank");
-    }
-  });
-}
-
-function fetchActs(){
-  var url = buildActivitiesUrl();
-  return fetch(url, { credentials: "include", mode: "cors" }).then(function(res){
-
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return res.json();
-  }).then(function(body){
-    return body && body.results ? body.results : {};
-  }).catch(function(err){
-    console.error("watch_status error", err);
-    return {};
-  });
-}
-
-function fetchWatchStatus(chatId, urls){
-  if (!chatId || !Array.isArray(urls) || urls.length === 0) return Promise.resolve({});
-  var unique = [];
-  var seen = {};
-  urls.forEach(function(u){
-    if (typeof u !== "string") return;
-    var val = u.trim();
-    if (!val || seen[val]) return;
-    seen[val] = true;
-    unique.push(val);
-  });
-  if (unique.length === 0) return Promise.resolve({});
-
-  return fetch(STATUS_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    mode: "cors",
-    body: JSON.stringify({ chatId: chatId, urls: unique })
-  }).then(function(res){
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return res.json();
-  }).then(function(body){
-    return body && body.results ? body.results : {};
-  }).catch(function(err){
-    console.error("watch_status error", err);
-    return {};
-  });
-}
-
-function fetchWatchStatus(chatId, urls){
-  if (!chatId || !Array.isArray(urls) || urls.length === 0) return Promise.resolve({});
-  var unique = [];
-  var seen = {};
-  urls.forEach(function(u){
-    if (typeof u !== "string") return;
-    var val = u.trim();
-    if (!val || seen[val]) return;
-    seen[val] = true;
-    unique.push(val);
-  });
-  if (unique.length === 0) return Promise.resolve({});
-
-  return fetch(STATUS_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    mode: "cors",
-    body: JSON.stringify({ chatId: chatId, urls: unique })
-  }).then(function(res){
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return res.json();
-  }).then(function(body){
-    return body && body.results ? body.results : {};
-  }).catch(function(err){
-    console.error("watch_status error", err);
-    return {};
-  });
-}
-
-function fetchWatchStatus(chatId, urls){
-  if (!chatId || !Array.isArray(urls) || urls.length === 0) return Promise.resolve({});
-  var unique = [];
-  var seen = {};
-  urls.forEach(function(u){
-    if (typeof u !== "string") return;
-    var val = u.trim();
-    if (!val || seen[val]) return;
-    seen[val] = true;
-    unique.push(val);
-  });
-  if (unique.length === 0) return Promise.resolve({});
-
-  return fetch(STATUS_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    mode: "cors",
-    body: JSON.stringify({ chatId: chatId, urls: unique })
-  }).then(function(res){
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return res.json();
-  }).then(function(body){
-    return body && body.results ? body.results : {};
-  }).catch(function(err){
-    console.error("watch_status error", err);
-    return {};
-  });
-}
-
-function fetchWatchStatus(chatId, urls){
-  if (!chatId || !Array.isArray(urls) || urls.length === 0) return Promise.resolve({});
-  var unique = [];
-  var seen = {};
-  urls.forEach(function(u){
-    if (typeof u !== "string") return;
-    var val = u.trim();
-    if (!val || seen[val]) return;
-    seen[val] = true;
-    unique.push(val);
-  });
-  if (unique.length === 0) return Promise.resolve({});
-
-  return fetch(STATUS_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    mode: "cors",
-    body: JSON.stringify({ chatId: chatId, urls: unique })
-  }).then(function(res){
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    return res.json();
-  }).then(function(body){
-    return body && body.results ? body.results : {};
-  }).catch(function(err){
-    console.error("watch_status error", err);
-    return {};
-  });
-}
-
-function el(tag, cls, html){
-  var d = document.createElement(tag);
-  if (cls) d.className = cls;
-  if (html != null) d.innerHTML = html;
-  return d;
-}
-
-function resolveChatId(){
-  if (!liff.isInClient()) return Promise.resolve(null);
-  try {
-    var ctx = liff.getContext();
-    if (ctx) {
-      if (ctx.type === "group" && ctx.groupId) return Promise.resolve(ctx.groupId);
-      if (ctx.type === "room" && ctx.roomId) return Promise.resolve(ctx.roomId);
-      if (ctx.userId) return Promise.resolve(ctx.userId);
-    }
-  } catch (e) {
-    console.warn("getContext failed", e);
-  }
-  return liff.getProfile().then(function(p){
-    return p && p.userId ? p.userId : null;
-  }).catch(function(){ return null; });
-}
-
-function render(acts, ctx){
-  var elList = document.getElementById("list");
-  elList.innerHTML = "";
-
-  if (!Array.isArray(acts) || acts.length === 0){
-    elList.appendChild(el("div", "hint", "目前抓不到活動清單，請稍後再試。"));
-    return;
-  }
-
-  ctx = ctx || {};
-  var statusMap = ctx.statusMap || {};
-  var chatId = ctx.chatId || null;
-
-  acts.forEach(function(it, i){
-    var title = it.title || ("活動 " + (i + 1));
-    var url   = (it.url || "").trim();
-    var normUrl = url;
-    var status = statusMap[normUrl];
-    if (!status) {
-      status = statusMap[normUrl] = { watching: false, enabled: false, taskId: null };
-    }
-
-    var card = el("div", "card", "");
-    card.appendChild(el("div", "title", String(i+1).padStart(2,"0") + ". " + title));
-
-    if (it.image){
-      var img = el("img", "poster", "");
-      img.src = it.image;
-      img.alt = title;
-
-      if (url){
-        img.style.cursor = "pointer";
-        attachExternalHandler(img, url);
-      }
-
-      card.appendChild(img);
-    }
-
-    var row  = el("div", "row", "");
-    var link = el("a", null, "活動頁面");
-    if (url){
-      link.href = url;
-      link.target = "_blank";
-      attachExternalHandler(link, url);
-    }else{
-      link.className = "hint";
-      link.href = "javascript:void(0)";
-      link.innerHTML = "（無有效連結）";
-    }
-    row.appendChild(link);
-
-    card.appendChild(row);
-
-    var statusLabel = null;
-    if (status.taskId){
-      var text = status.enabled ? ("狀態：監看中｜任務 " + status.taskId) : ("狀態：任務 " + status.taskId + " 已停用");
-      statusLabel = el("div", "hint status", text);
-      card.appendChild(statusLabel);
-    } else if (status.found){
-      statusLabel = el("div", "hint status", "狀態：此活動已建立任務但目前未啟用");
-      card.appendChild(statusLabel);
-    }
-
-    var buttons = el("div", "row buttons", "");
-    var btnWatch = el("button", null, "✅ 監看");
-    btnWatch.onclick = function(){
-      if (!url){ alert("此活動沒有可用的 URL，無法監看。"); return; }
-      var s = ensureSec(document.getElementById("sec").value);
-      if (!liff.isInClient()){
-        alert("提示：目前不是從 LINE 內開啟，將僅開啟活動頁面。");
-        window.open(url, "_blank");
-        return;
-      }
-      var text = "/watch " + url + " " + s;
-      var original = btnWatch.textContent;
-      btnWatch.disabled = true; btnWatch.textContent = "送出中…";
-      liff.sendMessages([{ type:"text", text:text }]).then(function(){
-        alert("已送出監看指令到聊天室！");
-        if (statusLabel){
-          statusLabel.textContent = "狀態：已送出監看指令，請留意聊天室回覆任務代碼。";
-        } else {
-          statusLabel = el("div", "hint status", "狀態：已送出監看指令，請留意聊天室回覆任務代碼。");
-          card.appendChild(statusLabel);
-        }
-        status.enabled = true;
-        status.watching = true;
-
-        try {
-          liff.openWindow({ url: url, external: true });
-        } catch (err) {
-          console.warn("openWindow failed", err);
-        }
-
-      }).catch(function(e){
-        alert("送訊息或開啟頁面失敗：" + e);
-        console.error(e);
-      }).finally(function(){
-        btnWatch.disabled = false;
-        btnWatch.textContent = original;
-      });
+  <script>
+    window.LIFF_CONFIG = {
+      liffId: "2008066018-EMmpzmKo",
+      limit: 20,
     };
-    buttons.appendChild(btnWatch);
-
-    var btnStop = el("button", "danger", "⏹ 停止監看");
-    btnStop.onclick = function(){
-      if (!url){ alert("此活動沒有可用的 URL。"); return; }
-      if (!liff.isInClient()){
-        alert("請於 LINE 內使用停止監看功能。");
-        return;
-      }
-      if (!chatId){
-        alert("未取得聊天室識別，請重新開啟 LIFF 後再試一次。");
-        return;
-      }
-      if (!status.taskId || !status.enabled){
-        alert("此活動無監看");
-        return;
-      }
-      var original = btnStop.textContent;
-      btnStop.disabled = true; btnStop.textContent = "送出中…";
-      liff.sendMessages([{ type:"text", text:"/unwatch " + status.taskId }]).then(function(){
-        alert("已送出停止監看指令！");
-        status.enabled = false;
-        status.watching = false;
-        if (statusLabel){
-          statusLabel.textContent = "狀態：已送出停止監看指令，請留意聊天室回覆。";
-        } else {
-          statusLabel = el("div", "hint status", "狀態：已送出停止監看指令，請留意聊天室回覆。");
-          card.appendChild(statusLabel);
-        }
-      }).catch(function(e){
-        alert("送出停止監看失敗：" + e);
-        console.error(e);
-      }).finally(function(){
-        btnStop.disabled = false;
-        btnStop.textContent = original;
-      });
-    };
-    buttons.appendChild(btnStop);
-
-    var btnCheck = el("button", "secondary", "👀 快速查看");
-    btnCheck.onclick = function(){
-      if (!url){ alert("此活動沒有可用的 URL。"); return; }
-      if (!liff.isInClient()){
-        alert("提示：目前不是從 LINE 內開啟，將直接開啟活動頁面。");
-        window.open(url, "_blank");
-        return;
-      }
-      var original = btnCheck.textContent;
-      btnCheck.disabled = true; btnCheck.textContent = "送出中…";
-      liff.sendMessages([{ type:"text", text:"/check " + url }]).then(function(){
-        alert("已送出快速查看指令！");
-        if (statusLabel){
-          statusLabel.textContent = "狀態：已送出快速查看指令，請於聊天室查看回覆。";
-        } else {
-          statusLabel = el("div", "hint status", "狀態：已送出快速查看指令，請於聊天室查看回覆。");
-          card.appendChild(statusLabel);
-        }
-      }).catch(function(e){
-        alert("送出快速查看失敗：" + e);
-        console.error(e);
-      }).finally(function(){
-        btnCheck.disabled = false;
-        btnCheck.textContent = original;
-      });
-    };
-    buttons.appendChild(btnCheck);
-
-    card.appendChild(buttons);
-    elList.appendChild(card);
-  });
-}
-
-function showApiError(){
-  var elList = document.getElementById("list");
-  elList.innerHTML =
-    "<div class='card'><div class='title'>讀取活動清單失敗</div>" +
-    "<div class='hint'>請確認後端 " + API + " 是否 200 OK，並開啟 CORS。</div></div>";
-}
-
-function boot(){
-  var out = document.getElementById("out");
-  out.textContent = "LIFF 初始化中…";
-
-  var activities = [];
-
-  liff.init({ liffId: LIFF_ID }).then(function(){
-    var inClient = liff.isInClient();
-    if (!inClient){
-      out.textContent = "提示：請從 LINE 內開啟此頁，以便直接把指令送回聊天室。";
-    }else{
-      out.textContent = "";
-    }
-
-    return fetchActs().then(function(acts){
-      activities = Array.isArray(acts) ? acts : [];
-      if (!inClient){
-        render(activities, { statusMap: {} });
-        return;
-      }
-      return resolveChatId().then(function(chatId){
-        return fetchWatchStatus(chatId, activities.map(function(it){ return it && it.url ? it.url : ""; })).then(function(status){
-          render(activities, { statusMap: status, chatId: chatId });
-        });
-      });
-    }).catch(function(e){
-      console.error(e); showApiError();
-    });
-  }).catch(function(e){
-    console.error(e);
-    out.textContent = "LIFF 初始化失敗或 API 取用失敗。";
-    showApiError();
-  });
-}
-
-document.getElementById("reload").onclick = boot;
-boot();
-</script>
+  </script>
+  <script src="/liff/main.js"></script>
 </body>
 </html>

--- a/liff/main.js
+++ b/liff/main.js
@@ -1,0 +1,466 @@
+(function(){
+  const CONFIG = window.LIFF_CONFIG || {};
+  const LIFF_ID = CONFIG.liffId || "";
+  const API_ROOT = CONFIG.apiRoot || "/api/liff";
+  const STATUS_API = CONFIG.statusApi || "/liff/watch_status";
+  const LIMIT = Math.max(1, Math.min(50, Number(CONFIG.limit) || 20));
+  const PLACEHOLDER_IMAGE = CONFIG.placeholderImage ||
+    "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='640' height='360'><rect width='640' height='360' fill='%23f0f1f6'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='28' font-family='Arial' fill='%238896a9'>暫無圖片</text></svg>";
+
+  const state = {
+    chatId: null,
+    statusMap: {},
+    items: [],
+    isClient: false,
+    loading: false,
+  };
+
+  const elOut = document.getElementById("out");
+  const elList = document.getElementById("list");
+  const elReload = document.getElementById("reload");
+  const elSec = document.getElementById("sec");
+
+  function setStatus(text){
+    if (elOut) elOut.textContent = text || "";
+  }
+
+  function ensureSec(v){
+    const n = parseInt(v, 10);
+    if (Number.isNaN(n) || n < 15) return 15;
+    return n;
+  }
+
+  function canonicalUrl(url){
+    try {
+      const u = new URL(url);
+      u.hash = "";
+      u.searchParams.sort?.();
+      return u.toString();
+    } catch (e) {
+      return url;
+    }
+  }
+
+  function updateWatchState(url, data){
+    const key = canonicalUrl(url);
+    const entry = state.statusMap[key] || {};
+    state.statusMap[key] = Object.assign({}, entry, data);
+  }
+
+  function createMetaLine(label, value){
+    if (!value) return null;
+    const span = document.createElement("span");
+    span.textContent = `${label} ${value}`;
+    return span;
+  }
+
+  function createCard(item, index){
+    const card = document.createElement("article");
+    card.className = "card";
+    card.dataset.url = item.url || "";
+
+    const title = document.createElement("div");
+    title.className = "title";
+    title.textContent = `${String(index + 1).padStart(2, "0")}. ${item.title || "活動"}`;
+    card.appendChild(title);
+
+    const img = document.createElement("img");
+    img.src = item.image_url || PLACEHOLDER_IMAGE;
+    img.alt = item.title || "活動圖片";
+    img.onerror = () => {
+      if (img.src !== PLACEHOLDER_IMAGE) {
+        img.src = PLACEHOLDER_IMAGE;
+      }
+    };
+    card.appendChild(img);
+
+    const meta = document.createElement("div");
+    meta.className = "meta";
+    const dateLine = createMetaLine("📅", item.date_text || item.date || "");
+    const placeLine = createMetaLine("📍", item.place || "");
+    if (dateLine) meta.appendChild(dateLine);
+    if (placeLine) meta.appendChild(placeLine);
+    card.appendChild(meta);
+
+    const links = document.createElement("div");
+    links.className = "links";
+    if (item.url){
+      const anchor = document.createElement("a");
+      anchor.href = item.url;
+      anchor.target = "_blank";
+      anchor.rel = "noopener";
+      anchor.textContent = "活動頁面";
+      links.appendChild(anchor);
+    }
+    card.appendChild(links);
+
+    const statusText = document.createElement("div");
+    statusText.className = "status-text";
+    statusText.textContent = item.status_text || "暫時讀不到剩餘數（可能為動態載入）";
+    card.appendChild(statusText);
+
+    const watchInfo = document.createElement("div");
+    watchInfo.className = "watch-state";
+    card.appendChild(watchInfo);
+
+    const buttons = document.createElement("div");
+    buttons.className = "buttons";
+
+    const btnWatch = document.createElement("button");
+    btnWatch.className = "primary btn-watch";
+    btnWatch.type = "button";
+    btnWatch.textContent = "✅ 開始監看";
+    btnWatch.addEventListener("click", () => handleWatch(item, card, statusText, watchInfo, feedback));
+    buttons.appendChild(btnWatch);
+
+    const btnStop = document.createElement("button");
+    btnStop.className = "danger btn-stop";
+    btnStop.type = "button";
+    btnStop.textContent = "⏹ 停止監看";
+    btnStop.addEventListener("click", () => handleUnwatch(item, card, statusText, watchInfo, feedback));
+    buttons.appendChild(btnStop);
+
+    const btnQuick = document.createElement("button");
+    btnQuick.className = "secondary btn-quick";
+    btnQuick.type = "button";
+    btnQuick.textContent = "⚡ 快速查看";
+    btnQuick.addEventListener("click", () => handleQuickCheck(item, card, statusText, feedback));
+    buttons.appendChild(btnQuick);
+
+    card.appendChild(buttons);
+
+    const feedback = document.createElement("div");
+    feedback.className = "feedback";
+    card.appendChild(feedback);
+
+    updateCardWatchInfo(item.url, watchInfo);
+    return card;
+  }
+
+  function updateCardWatchInfo(url, watchInfo){
+    if (!watchInfo) return;
+    const key = canonicalUrl(url);
+    const status = state.statusMap[key];
+    if (status && status.taskId){
+      watchInfo.textContent = status.enabled ? `狀態：監看中｜任務 ${status.taskId}` : `狀態：任務 ${status.taskId} 已停用`;
+    } else if (status && status.found){
+      watchInfo.textContent = "狀態：此活動已建立任務但目前未啟用";
+    } else {
+      watchInfo.textContent = "";
+    }
+  }
+
+  function setCardFeedback(feedbackNode, message){
+    if (!feedbackNode) return;
+    feedbackNode.textContent = message || "";
+  }
+
+  function setButtonsDisabled(card, disabled){
+    card.querySelectorAll("button").forEach(btn => {
+      btn.disabled = disabled;
+    });
+  }
+
+  async function handleWatch(item, card, statusText, watchInfo, feedback){
+    if (!item.url){
+      alert("此活動沒有可用的 URL，無法監看。");
+      return;
+    }
+    if (!state.chatId){
+      alert("尚未取得聊天室識別，請重新開啟 LIFF 再試一次。");
+      return;
+    }
+    const sec = ensureSec(elSec ? elSec.value : 30);
+    const payload = { chat_id: state.chatId, url: item.url, period: sec };
+    const btn = card.querySelector(".btn-watch");
+    const original = btn ? btn.textContent : "";
+    if (btn) {
+      btn.disabled = true;
+      btn.textContent = "送出中…";
+    }
+    setCardFeedback(feedback, "送出監看請求中…");
+    try {
+      const res = await fetch(`${API_ROOT}/watch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok){
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      updateWatchState(item.url, { watching: true, enabled: true, taskId: body.task_id, found: true });
+      updateCardWatchInfo(item.url, watchInfo);
+      setCardFeedback(feedback, body.message || "已開始監看。");
+      if (body.detail && body.detail.status_text){
+        statusText.textContent = body.detail.status_text;
+      }
+    } catch (err) {
+      console.error("watch failed", err);
+      alert(`開始監看失敗：${err.message || err}`);
+      setCardFeedback(feedback, "開始監看失敗，請稍後再試。");
+    } finally {
+      if (btn){
+        btn.disabled = false;
+        btn.textContent = original || "✅ 開始監看";
+      }
+    }
+  }
+
+  async function handleUnwatch(item, card, statusText, watchInfo, feedback){
+    if (!item.url){
+      alert("此活動沒有可用的 URL。");
+      return;
+    }
+    if (!state.chatId){
+      alert("尚未取得聊天室識別，請重新開啟 LIFF 再試一次。");
+      return;
+    }
+    const key = canonicalUrl(item.url);
+    const current = state.statusMap[key] || {};
+    if (!current.taskId && !current.enabled){
+      alert("此活動無監看");
+      return;
+    }
+    const payload = { chat_id: state.chatId, url: item.url };
+    if (current.taskId){
+      payload.task_code = current.taskId;
+    }
+    const btn = card.querySelector(".btn-stop");
+    const original = btn ? btn.textContent : "";
+    if (btn){
+      btn.disabled = true;
+      btn.textContent = "送出中…";
+    }
+    setCardFeedback(feedback, "送出停止監看請求中…");
+    try {
+      const res = await fetch(`${API_ROOT}/unwatch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json();
+      if (!res.ok){
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      if (body.ok){
+        updateWatchState(item.url, { watching: false, enabled: false, taskId: body.task_id || current.taskId, found: true });
+      }
+      updateCardWatchInfo(item.url, watchInfo);
+      setCardFeedback(feedback, body.message || "已送出停止監看。" );
+    } catch (err) {
+      console.error("unwatch failed", err);
+      alert(`停止監看失敗：${err.message || err}`);
+      setCardFeedback(feedback, "停止監看失敗，請稍後再試。");
+    } finally {
+      if (btn){
+        btn.disabled = false;
+        btn.textContent = original || "⏹ 停止監看";
+      }
+    }
+  }
+
+  async function handleQuickCheck(item, card, statusText, feedback){
+    if (!item.url){
+      alert("此活動沒有可用的 URL。");
+      return;
+    }
+    setButtonsDisabled(card, true);
+    setCardFeedback(feedback, "快速查看中…");
+    try {
+      const res = await fetch(`${API_ROOT}/quick-check`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ url: item.url }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok){
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      if (body.detail && body.detail.status_text){
+        statusText.textContent = body.detail.status_text;
+      }
+      setCardFeedback(feedback, "已取得最新票數資訊，請查看訊息。");
+      if (body.message){
+        if (state.isClient){
+          try {
+            await liff.sendMessages([{ type: "text", text: body.message }]);
+          } catch (e) {
+            console.warn("sendMessages failed", e);
+          }
+        }
+        alert(body.message);
+      }
+    } catch (err) {
+      console.error("quick-check failed", err);
+      alert(`快速查看失敗：${err.message || err}`);
+      setCardFeedback(feedback, "快速查看失敗，請稍後再試。");
+    } finally {
+      setButtonsDisabled(card, false);
+    }
+  }
+
+  async function fetchConcerts(mode){
+    const url = new URL(`${API_ROOT}/concerts`, window.location.origin);
+    url.searchParams.set("mode", mode);
+    url.searchParams.set("limit", String(LIMIT));
+    const res = await fetch(url.toString(), { credentials: "include" });
+    if (!res.ok){
+      const text = await res.text();
+      throw new Error(`HTTP ${res.status} ${text}`);
+    }
+    return res.json();
+  }
+
+  async function fetchWatchStatus(chatId, urls){
+    if (!chatId || !Array.isArray(urls) || urls.length === 0) return {};
+    const unique = [];
+    const seen = new Set();
+    urls.forEach((raw) => {
+      if (typeof raw !== "string") return;
+      const val = raw.trim();
+      if (!val || seen.has(val)) return;
+      seen.add(val);
+      unique.push(val);
+    });
+    if (!unique.length) return {};
+    const res = await fetch(STATUS_API, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ chatId, urls: unique }),
+    });
+    if (!res.ok){
+      throw new Error(`HTTP ${res.status}`);
+    }
+    const body = await res.json();
+    return body && body.results ? body.results : {};
+  }
+
+  function render(items){
+    if (!elList) return;
+    elList.innerHTML = "";
+    if (!Array.isArray(items) || items.length === 0){
+      const empty = document.createElement("div");
+      empty.className = "empty-message";
+      empty.textContent = "目前抓不到活動清單，請稍後再試。";
+      elList.appendChild(empty);
+      return;
+    }
+    items.forEach((item, idx) => {
+      const card = createCard(item, idx);
+      elList.appendChild(card);
+    });
+  }
+
+  async function loadConcerts(){
+    if (state.loading) return;
+    state.loading = true;
+    setStatus("載入活動清單中…");
+    try {
+      let data = await fetchConcerts("carousel");
+      let sourceMode = data && data.source_mode ? data.source_mode : "carousel";
+      if (!data || !Array.isArray(data.results) || data.results.length === 0){
+        const fallback = await fetchConcerts("all");
+        if (fallback && Array.isArray(fallback.results) && fallback.results.length){
+          data = fallback;
+          sourceMode = fallback.source_mode || "all";
+        }
+      }
+      const items = (data && Array.isArray(data.results)) ? data.results : [];
+      state.items = items;
+      const urls = items.map(it => it.url).filter(Boolean);
+      try {
+        const statusMapRaw = await fetchWatchStatus(state.chatId, urls);
+        state.statusMap = {};
+        Object.keys(statusMapRaw).forEach((key) => {
+          const entry = statusMapRaw[key];
+          state.statusMap[canonicalUrl(key)] = entry;
+        });
+      } catch (e){
+        console.warn("fetchWatchStatus failed", e);
+      }
+      render(items);
+      setStatus(items.length ? `共 ${items.length} 筆活動${sourceMode === "all" ? "（使用備援資料）" : ""}` : "目前抓不到活動清單，請稍後再試。");
+    } catch (err) {
+      console.error("loadConcerts failed", err);
+      setStatus(`載入失敗：${err.message || err}`);
+      elList.innerHTML = "";
+      const empty = document.createElement("div");
+      empty.className = "empty-message";
+      empty.textContent = "目前抓不到活動清單，請稍後再試。";
+      elList.appendChild(empty);
+    } finally {
+      state.loading = false;
+    }
+  }
+
+  async function resolveChatId(){
+    if (!window.liff) return null;
+    if (!state.isClient) {
+      try {
+        const profile = await liff.getProfile();
+        if (profile && profile.userId) return profile.userId;
+      } catch (e) {
+        console.warn("getProfile failed", e);
+      }
+      return null;
+    }
+    try {
+      const ctx = liff.getContext();
+      if (ctx){
+        if (ctx.type === "group" && ctx.groupId) return ctx.groupId;
+        if (ctx.type === "room" && ctx.roomId) return ctx.roomId;
+        if (ctx.userId) return ctx.userId;
+      }
+    } catch (e) {
+      console.warn("getContext failed", e);
+    }
+    try {
+      const profile = await liff.getProfile();
+      if (profile && profile.userId) return profile.userId;
+    } catch (e) {
+      console.warn("getProfile failed", e);
+    }
+    return null;
+  }
+
+  async function init(){
+    if (!window.liff){
+      setStatus("找不到 LIFF SDK，請稍後再試。");
+      return;
+    }
+    setStatus("初始化 LIFF 中…");
+    try {
+      if (LIFF_ID){
+        await liff.init({ liffId: LIFF_ID });
+      } else {
+        await liff.init({});
+      }
+      state.isClient = liff.isInClient();
+    } catch (err) {
+      console.error("liff.init failed", err);
+      setStatus("LIFF 初始化失敗，請稍後再試。");
+      return;
+    }
+
+    try {
+      state.chatId = await resolveChatId();
+    } catch (e){
+      console.warn("resolveChatId failed", e);
+    }
+
+    if (elReload){
+      elReload.addEventListener("click", () => {
+        loadConcerts();
+      });
+    }
+
+    loadConcerts();
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+})();


### PR DESCRIPTION
## Summary
- add cached ibon detail parsing and expose /api/liff endpoints for concerts, watch, unwatch, and quick check
- update concert aggregation to enrich cards with titles, dates, locations, and status details
- rebuild the LIFF page with refreshed layout and buttons wired to the new backend APIs

## Testing
- python3 -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68f1094adfac832ebba896f43e23a32f