### PR TITLE
Refine ibon LIFF activity parsing and resilience

### DIFF
--- a/liff/index.html
+++ b/liff/index.html
@@ -199,14 +199,39 @@
       const elSec = document.getElementById("sec");
 
       function buildStatusLine(item){
-        if (!item) return "暫時讀不到剩餘數（可能為動態載入）";
+        const fallbackText = "暫時讀不到剩餘數（可能為動態載入）";
+        if (!item) return fallbackText;
+
+        const tickets = Array.isArray(item.tickets) ? item.tickets : [];
+        if (tickets.length){
+          const parts = tickets.slice(0, 3).map(t => {
+            if (!t || typeof t !== "object") return null;
+            const area = t.area || "";
+            const price = (typeof t.price === "number" && Number.isFinite(t.price))
+              ? `NT$${t.price.toLocaleString("zh-TW")}`
+              : "";
+            const remaining = (typeof t.remaining === "number" && Number.isFinite(t.remaining))
+              ? `${t.remaining} 張`
+              : "";
+            const segments = [area, price, remaining].filter(Boolean);
+            return segments.join(" ");
+          }).filter(Boolean);
+          if (parts.length){
+            let line = parts.join("｜");
+            if (tickets.length > parts.length){
+              line += "｜...";
+            }
+            return line;
+          }
+        }
+
         if (typeof item.remain === "number" && Number.isFinite(item.remain)){
           return `剩餘 ${item.remain} 張`;
         }
         if (item.status_text){
           return item.status_text;
         }
-        return "暫時讀不到剩餘數（可能為動態載入）";
+        return fallbackText;
       }
 
       function setStatus(text){

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,14 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app import app as flask_app
+from app import (  # noqa: E402
+    app as flask_app,
+    build_ibon_details_url,
+    sanitize_details_url,
+    _clean_venue_text,
+    _collect_datetime_candidates,
+    _parse_price_value,
+)
 
 
 @pytest.fixture()
@@ -30,6 +37,55 @@ def test_api_liff_concerts(client):
     _assert_status(resp, {200})
 
 
+def test_api_liff_concerts_debug_trace(client):
+    resp = client.get("/api/liff/concerts", query_string={"debug": "1"})
+    _assert_status(resp, {200})
+    payload = resp.get_json()
+    assert isinstance(payload, dict)
+    assert "trace" in payload
+    assert isinstance(payload["trace"], list)
+
+
+def test_helper_build_and_sanitize_details_url():
+    built = build_ibon_details_url("39125", "ENTERTAINMENT")
+    assert built.endswith("id=39125&pattern=ENTERTAINMENT")
+    messy = "https://ticket.ibon.com.tw/ActivityInfo/Details/39125?foo=1"
+    cleaned = sanitize_details_url(messy)
+    assert cleaned.endswith("id=39125&pattern=ENTERTAINMENT")
+
+
+def test_clean_venue_text_removes_time():
+    raw = "TICC 臺北國際會議中心 18:00"
+    cleaned = _clean_venue_text(raw)
+    assert cleaned == "TICC 臺北國際會議中心"
+
+
+def test_collect_datetime_candidates_filters_sale():
+    lines = [
+        "售票期間：2024/05/01 10:00",
+        "演出日期：2024/06/10 19:30",
+    ]
+    candidates = _collect_datetime_candidates(lines)
+    assert candidates and candidates[0][0].year == 2024
+    assert candidates[0][0].month == 6
+
+
+def test_collect_datetime_candidates_skips_ranges():
+    lines = [
+        "演出日期：2024/07/01 19:30",
+        "演出時間 2024/07/01 19:30 ~ 21:30",
+        "活動時間 2024/07/02 14:00",
+    ]
+    candidates = _collect_datetime_candidates(lines)
+    assert candidates
+    for _, _, raw in candidates:
+        assert "~" not in raw and "～" not in raw
+
+
+def test_parse_price_value_handles_currency():
+    assert _parse_price_value("票價 NT$2,800") == 2800
+
+
 def test_api_liff_quick_check(client):
     resp = client.get("/api/liff/quick-check", query_string={"url": "https://example.com"})
     _assert_status(resp, {200})
@@ -39,4 +95,7 @@ def test_api_liff_quick_check(client):
 def test_watch_endpoints_no_firestore(client, endpoint):
     payload = {"chat_id": "test", "url": "https://example.com", "period": 60}
     resp = client.post(endpoint, data=json.dumps(payload), content_type="application/json")
-    _assert_status(resp, {200, 401, 403, 503})
+    _assert_status(resp, {200})
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert data.get("ok") is False


### PR DESCRIPTION
## Summary
- ensure ibon detail fetch decodes HTML with fallback, parse event date/venue from detail content, sanitize posters, and follow GoTicketURL using a shared session
- chain UTK0201 resolution through the same session with referer headers so tickets[] expose area/price/remaining while LIFF surfaces stable ActivityInfo detail links
- make webhook and LIFF watch/unwatch/quick-check endpoints respond immediately with background handling and `{ok:false}` error payloads, plus unit tests covering date parsing and API responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f1506db3f8832e9445ea6e9f10d964