### PR TITLE
Fix diag browser route registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,8 @@ from flask import (
 liff_api_bp = Blueprint("liff_api", __name__, url_prefix="/api/liff")
 main_bp = Blueprint("main", __name__)
 
-@app.get("/diag/browser")
+
+@main_bp.get("/diag/browser")
 def diag_browser():
     try:
         chrome = os.environ.get("CHROME_BIN") or shutil.which("chromium") or shutil.which("chromium-browser")


### PR DESCRIPTION
## Summary
- register the diagnostic browser endpoint on the main blueprint so it is available during app creation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f1b9024774832eac60d2a74a7dfb33